### PR TITLE
Fixes setup.py reference to package text assets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     license='BSD-3-clause',
     scripts=['scripts/tab-replay', 'scripts/always-tab-complete.py'],
     packages=find_packages(),
-    package_data={'assets': ['*.txt']},
+    package_data={'': ['assets/*.txt']},
     python_requires='>=3.8',
     install_requires=['bibtexparser>=1.0', 'Click', 'flake8', 'mypy',
                       'networkx', 'pandas', 'pyyaml>=5.3', 'types-setuptools',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     license='BSD-3-clause',
     scripts=['scripts/tab-replay', 'scripts/always-tab-complete.py'],
     packages=find_packages(),
-    package_data={'how-tos': ['assets/*.txt']},
+    package_data={'assets': ['*.txt']},
     python_requires='>=3.8',
     install_requires=['bibtexparser>=1.0', 'Click', 'flake8', 'mypy',
                       'networkx', 'pandas', 'pyyaml>=5.3', 'types-setuptools',


### PR DESCRIPTION
closes #92

The previous key broke the contract (docs [1](https://setuptools.pypa.io/en/latest/deprecated/distutils/setupscript.html?highlight=package_data#installing-package-data), [2](https://setuptools.pypa.io/en/latest/deprecated/distutils/sourcedist.html?highlight=package_data#specifying-the-files-to-distribute)) that keys should be module/package names. This was hidden by the fact that during development installs were performed with the `-e` editable flag, which retained access to the original package-data locations. The failure in `setup.py` meant the expected files weren't available when installed with `pip install .`

NOTE: `provenance_lib.egg-info/SOURCES.txt` is used after `setup.py` to specify package data for inclusion. If you're `setup.py` included some files and they were written to `SOURCES.txt`, that file (or the relevant lines) will need to be removed in order to see an accurate representation of the results of a `setup.py` build. Here, failure to delete that file masked the brokenness of the first commit on my local machine.